### PR TITLE
Add Preview Route

### DIFF
--- a/lib/ghost-admin.ts
+++ b/lib/ghost-admin.ts
@@ -1,0 +1,42 @@
+import { parse as urlParse } from 'url'
+import { Params } from '@tryghost/content-api'
+import GhostAdminAPI from '@tryghost/admin-api'
+import { normalizePost } from '@lib/ghost-normalize'
+import { getAllSettings, GhostPostOrPage } from '@lib/ghost';
+
+import { ghostAdminAPIKey, ghostAPIUrl } from '@lib/processEnv'
+
+const adminApi = new GhostAdminAPI({
+  url: ghostAPIUrl,
+  key: ghostAdminAPIKey,
+  version: 'v3',
+})
+
+const postPreviewFetchOptions: Params = {
+  limit: 'all',
+  include: ['tags', 'authors', 'count.posts'],
+  order: ['featured DESC', 'published_at DESC'],
+}
+
+export async function getPostPreviewById(id: string): Promise<GhostPostOrPage | null> {
+  let result: GhostPostOrPage
+
+  try {
+    const post = (await adminApi.posts.browse({
+      ...postPreviewFetchOptions,
+      filter: `uuid:${id}`,
+      formats: `html`,
+    }))[0]
+
+    // older Ghost versions do not throw error on 404
+    if (!post) return null
+
+    const { url } = await getAllSettings()
+    result = await normalizePost(post, (url && urlParse(url)) || undefined)
+  } catch (e) {
+    const error = e as { response?: { status: number } }
+    if (error.response?.status === 404) return null
+    throw e
+  }
+  return result
+}

--- a/lib/processEnv.ts
+++ b/lib/processEnv.ts
@@ -2,8 +2,9 @@ import * as appConfig from '@appConfig'
 import { NavItem } from '@lib/ghost'
 
 // siteUrl, platform, ghostAPIUrl, ghostAPIKey must be defined here
-export const ghostAPIUrl = process.env.CMS_GHOST_API_URL || 'https://cms.gotsby.org'
-export const ghostAPIKey = process.env.CMS_GHOST_API_KEY || '387f956eaa95345f7bb484d0b8'
+export const ghostAPIUrl = process.env.CMS_GHOST_API_URL
+export const ghostAPIKey = process.env.CMS_GHOST_API_KEY
+export const ghostAdminAPIKey = process.env.CMS_GHOST_ADMIN_API_KEY
 
 const siteUrl = process.env.SITE_URL || (process.env.VERCEL_URL && `https://${process.env.VERCEL_URL}`) || process.env.URL || 'http://localhost:3000'
 

--- a/lib/processEnv.ts
+++ b/lib/processEnv.ts
@@ -2,8 +2,8 @@ import * as appConfig from '@appConfig'
 import { NavItem } from '@lib/ghost'
 
 // siteUrl, platform, ghostAPIUrl, ghostAPIKey must be defined here
-export const ghostAPIUrl = process.env.CMS_GHOST_API_URL
-export const ghostAPIKey = process.env.CMS_GHOST_API_KEY
+export const ghostAPIUrl = process.env.CMS_GHOST_API_URL || 'https://cms.gotsby.org'
+export const ghostAPIKey = process.env.CMS_GHOST_API_KEY || '387f956eaa95345f7bb484d0b8'
 export const ghostAdminAPIKey = process.env.CMS_GHOST_ADMIN_API_KEY
 
 const siteUrl = process.env.SITE_URL || (process.env.VERCEL_URL && `https://${process.env.VERCEL_URL}`) || process.env.URL || 'http://localhost:3000'

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "serve": "serve out"
   },
   "dependencies": {
+    "@tryghost/admin-api": "^1.6.0",
     "@tryghost/content-api": "^1.6.0",
     "cheerio": "^1.0.0-rc.10",
     "crypto-hash": "^2.0.1",

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -40,7 +40,7 @@ interface CmsData extends CmsDataCore {
   isPost: boolean
 }
 
-interface PostOrPageProps {
+export interface PostOrPageProps {
   cmsData: CmsData
 }
 

--- a/pages/p/[pid].tsx
+++ b/pages/p/[pid].tsx
@@ -1,0 +1,57 @@
+import { GetServerSideProps } from 'next'
+
+import { Post } from '@components/Post'
+
+import { GhostPostOrPage } from '@lib/ghost'
+import { getPostPreviewById } from '@lib/ghost-admin'
+
+import { getAllSettings, GhostPostsOrPages } from '@lib/ghost'
+import { seoImage } from '@meta/seoImage'
+
+import { PostOrPageProps } from '../[...slug]'
+
+const Pid = ({ cmsData }: PostOrPageProps) => {
+  return <Post {...{ cmsData }} />
+}
+
+export default Pid
+
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+  if (!(params && params.pid && Array.isArray(params.pid))) throw Error('getStaticProps: wrong parameters.')
+  const [pid] = params.pid.reverse()
+
+  console.time('Post Preview - getStaticProps')
+
+  const settings = await getAllSettings()
+
+  let post: GhostPostOrPage | null = null
+
+  post = await getPostPreviewById(pid);
+
+  let previewPosts: GhostPostsOrPages | never[] = []
+  let prevPost: GhostPostOrPage | null = null
+  let nextPost: GhostPostOrPage | null = null
+
+  const siteUrl = settings.processEnv.siteUrl
+  const imageUrl = (post)?.feature_image || undefined
+  const image = await seoImage({ siteUrl, imageUrl })
+
+  console.timeEnd('Post Preview - getStaticProps')
+
+  return {
+    props: {
+      cmsData: {
+        settings,
+        post,
+        // page,
+        // isPost,
+        seoImage: image,
+        previewPosts,
+        prevPost,
+        nextPost,
+        // bodyClass: BodyClass({ isPost, page: contactPage || page || undefined, tags }),
+      },
+    },
+  }
+}
+

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,3 +1,5 @@
+declare module '@tryghost/admin-api'
+
 declare module 'hast-util-to-string' {
   import { Node } from 'unist'
   export default function toString(node: Node): string

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,6 +246,15 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
 
+"@tryghost/admin-api@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/admin-api/-/admin-api-1.6.0.tgz#9e51e9704a6b2fca5ae8dcbef65e9f16c78e9f4a"
+  integrity sha512-o5rPUSa2eJCuLl5WqknWwlEeCQ9CuF33ZV/g8QB/rz7/se3aYRDCa/EPxM0bxo9OfBYlnGa8WkMnJzlzw9GeKw==
+  dependencies:
+    axios "^0.21.1"
+    form-data "^4.0.0"
+    jsonwebtoken "^8.4.0"
+
 "@tryghost/content-api@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@tryghost/content-api/-/content-api-1.6.0.tgz#232e79e63d1ccd27383b1206c0e1a140e995e1bd"
@@ -722,6 +731,11 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
 autoprefixer@^10.4.2:
   version "10.4.2"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.2.tgz#25e1df09a31a9fba5c40b578936b90d35c9d4d3b"
@@ -819,6 +833,11 @@ browserslist@^4.19.1:
     escalade "^3.1.1"
     node-releases "^2.0.1"
     picocolors "^1.0.0"
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
 
 buffer@^5.5.0:
   version "5.7.1"
@@ -994,6 +1013,13 @@ color@^4.0.1:
   dependencies:
     color-convert "^2.0.1"
     color-string "^1.9.0"
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 comma-separated-tokens@^1.0.0:
   version "1.0.8"
@@ -1227,6 +1253,11 @@ define-properties@^1.1.3:
   dependencies:
     object-keys "^1.0.12"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
@@ -1302,6 +1333,13 @@ duplexer@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 electron-to-chromium@^1.4.17:
   version "1.4.46"
@@ -1755,6 +1793,15 @@ follow-redirects@^1.14.0:
   version "1.14.7"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
   integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fraction.js@^4.1.2:
   version "4.1.2"
@@ -2333,6 +2380,22 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+jsonwebtoken@^8.4.0:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz#720b97bfe7d901b927d87c3773637ae8ea48781b"
@@ -2340,6 +2403,23 @@ json5@^1.0.1:
   dependencies:
     array-includes "^3.1.3"
     object.assign "^4.1.2"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 language-subtag-registry@~0.3.2:
   version "0.3.21"
@@ -2369,10 +2449,45 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.throttle@^4.1.1:
   version "4.1.1"
@@ -2455,7 +2570,7 @@ mime-types@2.1.18:
   dependencies:
     mime-db "~1.33.0"
 
-mime-types@~2.1.24:
+mime-types@^2.1.12, mime-types@~2.1.24:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
   integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
@@ -3600,7 +3715,7 @@ screenfull@^5.1.0:
   resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.2.0.tgz#6533d524d30621fc1283b9692146f3f13a93d1ba"
   integrity sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==
 
-semver@^5.5.0:
+semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==


### PR DESCRIPTION
Fixes #1 

Adds a route to preview unpublished posts at the default `/p/[pid]` route that the Ghost CMS UI specifies. 