### PR TITLE
Update Site URL

### DIFF
--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -1,6 +1,6 @@
 module.exports = {
   // see https://github.com/iamvishnusankar/next-sitemap
-  siteUrl: 'https://next.jamify.org',
+  siteUrl: process.env.SITE_URL || 'https://engineering.deptagency.com',
   generateRobotsTxt: true,
   sitemapSize: 7000,
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,8 +3,8 @@ User-agent: *
 Allow: /
 
 # Host
-Host: https://next.jamify.org
+Host: https://engineering.deptagency.com
 
 # Sitemaps
-Sitemap: https://next.jamify.org/sitemap.xml
-Sitemap: https://next.jamify.org/sitemap-0.xml
+Sitemap: https://engineering.deptagency.com/sitemap.xml
+Sitemap: https://engineering.deptagency.com/sitemap-0.xml


### PR DESCRIPTION
Fixes #9 

Though we'll need to spin off another issue as I don't think you can update the public blog URL in a non self-hosted Ghost Admin UI.