### PR TITLE
Make sure post-card-large className is applied

### DIFF
--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -29,8 +29,8 @@ export const PostCard = ({ settings, post, num, isHome }: PostCardProps) => {
   const featImg = post.featureImage
   const readingTime = readingTimeHelper(post).replace(`min read`, text(`MIN_READ`))
   const postClass = PostClass({ tags: post.tags, isFeatured: post.featured, isImage: !!featImg })
-  const large = (featImg && num !== undefined && num < 1 && `post-card-large`) || ``
-  const isFirstPost = (featImg && num !== undefined && num < 1)
+  const large = (num !== undefined && num < 1 && `post-card-large`) || ``
+  const isFirstPost = (num !== undefined && num < 1)
   const authors = post?.authors?.filter((_, i) => (i < 2 ? true : false))
 
   if (isFirstPost) {


### PR DESCRIPTION
We hit a bug this morning where a Post was published that didn't have a Feature Image. This caused the excerpt text on the homepage to render incorrectly due to white styling not being applied. This change ensures that the `post-card-large` class will be applied even if there is no Feature Image.