### PR TITLE
Allow for injection of code in post header

### DIFF
--- a/components/Post/index.tsx
+++ b/components/Post/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
+import Head from 'next/head'
 import Image from 'next/image'
 import Link from 'next/link'
 import React from 'react'
@@ -66,6 +67,11 @@ export const Post = ({ cmsData }: PostProps) => {
   return (
     <>
       <SEO {...{ description, settings, seoImage, article: post, title }} />
+      {post.codeinjection_head && (
+        <Head>
+          <div dangerouslySetInnerHTML={{ __html: post.codeinjection_head }} />
+        </Head>
+      )}
       <Layout
         {...{ bodyClass, settings }}
         header={<Header {...{ settings }} />}


### PR DESCRIPTION
The Ghost Admin UI has a section for embedding script tags in both the header and footer. The normal Casper handlebars theme has support for this, but our Next implementation does not. This adds some naive functionality to enable that. The specific use case was for this post: `/benchmarking-rust-code-using-criterion-rs` so that the author can correctly display math equations. MathML is not supported enough, so a third party library was necessary.

The other option here is to have the author to supply images for the equations. Thoughts on this approach?