### PR TITLE
Fix wide image display in posts

### DIFF
--- a/styles/toc.css
+++ b/styles/toc.css
@@ -45,15 +45,6 @@ html.casper .kg-width-full {
   align-items: center;
 }
 
-html.casper .kg-gallery-card > *,
-html.casper .kg-width-wide > *,
-html.casper .kg-width-full > *,
-html.casper figure.kg-width-full:not(.fluid-image) {
-  margin-left: -50vw;
-  margin-right: -50vw;
-  z-index: 1;
-}
-
 /* Page styles */
 html.casper aside.toc {
   order: 1;


### PR DESCRIPTION
Images that were typically wider would break out of the content well. In the original template we used, there was some fancy image handling that we don't have any use for anymore. The user can still click on the image to embiggen it.

Before:
<img width="2391" alt="image" src="https://user-images.githubusercontent.com/801071/176320549-87382f78-d717-4def-9499-4bbe88d56648.png">

After:
<img width="2405" alt="image" src="https://user-images.githubusercontent.com/801071/176320577-31110d0f-b47d-43bd-8b25-d0b29be6e343.png">

Example of the original purpose:
<img width="2397" alt="image" src="https://user-images.githubusercontent.com/801071/176320678-b17ab0c8-c5a9-40c7-adac-bc4b0a7e3222.png">

