### PR TITLE
Create & use homegrown grid

### DIFF
--- a/components/FirstPost/index.tsx
+++ b/components/FirstPost/index.tsx
@@ -1,11 +1,11 @@
-import Grid from '@mui/material/Grid'
 import styled from '@emotion/styled'
 
 import { GhostPostOrPage, GhostSettings } from '@lib/ghost'
 
-import { PostCard } from '@components/PostCard'
+import { Grid } from '@components/Grid'
 import { spaces } from '@components/common/spaces'
 import { colors } from '@components/common/colors'
+import { PostCard } from '@components/PostCard'
 
 interface FirstPostItemProps {
   settings: GhostSettings

--- a/components/Grid/Grid.model.ts
+++ b/components/Grid/Grid.model.ts
@@ -12,6 +12,8 @@ export type GridJustifyContent =
   | 'space-evenly'
 export type GridAlignItems = GridBaseAlignment | 'baseline' | 'stretch'
 
+export type GridSpacing = number | Partial<Record<BREAKPOINT, number>>
+
 export interface GridProps extends Partial<Record<BREAKPOINT, GridFlexBasis>> {
   container?: boolean
   item?: boolean
@@ -19,5 +21,8 @@ export interface GridProps extends Partial<Record<BREAKPOINT, GridFlexBasis>> {
   direction?: GridDirection
   justifyContent?: GridJustifyContent
   alignItems?: GridAlignItems
+  spacing?: GridSpacing
+  rowSpacing?: GridSpacing
+  columnSpacing?: GridSpacing
   zeroMinWidth?: boolean
 }

--- a/components/Grid/Grid.model.ts
+++ b/components/Grid/Grid.model.ts
@@ -1,0 +1,22 @@
+import { BREAKPOINT } from '@components/common/spaces'
+
+export type GridDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse'
+export type GridWrap = 'nowrap' | 'wrap' | 'wrap-reverse'
+
+type GridBaseAlignment = 'flex-start' | 'flex-end' | 'center'
+export type GridJustifyContent =
+  | GridBaseAlignment
+  | 'space-between'
+  | 'space-around'
+  | 'space-evenly'
+export type GridAlignItems = GridBaseAlignment | 'baseline' | 'stretch'
+
+export interface GridProps extends Partial<Record<BREAKPOINT, number>> {
+  container?: boolean
+  item?: boolean
+  wrap?: GridWrap
+  direction?: GridDirection
+  justifyContent?: GridJustifyContent
+  alignItems?: GridAlignItems
+  zeroMinWidth?: boolean
+}

--- a/components/Grid/Grid.model.ts
+++ b/components/Grid/Grid.model.ts
@@ -1,5 +1,6 @@
 import { BREAKPOINT } from '@components/common/spaces'
 
+export type GridFlexBasis = number | 'auto'
 export type GridDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse'
 export type GridWrap = 'nowrap' | 'wrap' | 'wrap-reverse'
 
@@ -11,7 +12,7 @@ export type GridJustifyContent =
   | 'space-evenly'
 export type GridAlignItems = GridBaseAlignment | 'baseline' | 'stretch'
 
-export interface GridProps extends Partial<Record<BREAKPOINT, number>> {
+export interface GridProps extends Partial<Record<BREAKPOINT, GridFlexBasis>> {
   container?: boolean
   item?: boolean
   wrap?: GridWrap

--- a/components/Grid/Grid.stories.tsx
+++ b/components/Grid/Grid.stories.tsx
@@ -1,0 +1,180 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+
+import { colors } from '@components/common/colors'
+
+import { Grid } from './Grid'
+import { GridProps } from './Grid.model'
+
+// 1. Arg Types
+const disabledArgType = {
+  table: {
+    disable: true
+  }
+}
+const generateSelectArgType = (name: string, options: string[]) => ({
+  name,
+  control: { type: 'select' },
+  options
+})
+
+const wrapOptions = ['wrap', 'wrap-reverse', 'nowrap']
+const directionOptions = ['row', 'row-reverse', 'column', 'column-reverse']
+
+const baseAlignments = ['flex-start', 'flex-end', 'center']
+const justifyContentOptions = [
+  ...baseAlignments,
+  'space-between',
+  'space-around',
+  'space-evenly'
+]
+const alignItemsOptions = [...baseAlignments, 'baseline', 'stretch']
+
+const argTypes = {
+  theme: disabledArgType,
+  as: disabledArgType,
+  container: disabledArgType,
+  item: disabledArgType,
+  wrap: disabledArgType,
+  wrapContainer: generateSelectArgType('Container wrap', wrapOptions),
+  directionContainer: generateSelectArgType(
+    'Container direction',
+    directionOptions
+  ),
+  justifyContentContainer: generateSelectArgType(
+    'Container justifyContent',
+    justifyContentOptions
+  ),
+  alignItemsContainer: generateSelectArgType(
+    'Container alignItems',
+    alignItemsOptions
+  ),
+  zeroMinWidthContainer: {
+    name: 'Container zeroMinWidth',
+    control: { type: 'boolean' }
+  },
+  direction: generateSelectArgType('direction', directionOptions),
+  justifyContent: generateSelectArgType(
+    'justifyContent',
+    justifyContentOptions
+  ),
+  alignItems: generateSelectArgType('alignItems', alignItemsOptions)
+}
+
+// 2. Container & Item CSS Styles
+const containerStyles = {
+  border: `3px solid ${colors.onyx}`
+}
+const itemStyles = {
+  background: colors.yellow,
+  color: colors.onyx,
+
+  padding: '5px',
+  height: '100px',
+  width: '100px',
+
+  'line-height': '100px',
+  'font-weight': 'bold',
+  'font-size': '2em',
+  'text-align': 'center'
+}
+
+// 3. Story
+export default {
+  title: 'Grid',
+  component: Grid,
+  argTypes,
+  subcomponents: { Grid }
+} as ComponentMeta<typeof Grid>
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Template: ComponentStory<typeof Grid> = (args: Record<string, any>) => {
+  const itemArgs: GridProps = {
+    item: true,
+    direction: args.direction,
+    justifyContent: args.justifyContent,
+    alignItems: args.alignItems,
+    zeroMinWidth: args.zeroMinWidth,
+    xs: args.xs,
+    sm: args.sm,
+    md: args.md,
+    lg: args.lg,
+    xl: args.xl
+  }
+
+  return (
+    <Grid
+      container
+      wrap={args.wrapContainer}
+      direction={args.directionContainer}
+      justifyContent={args.justifyContentContainer}
+      alignItems={args.alignItemsContainer}
+      zeroMinWidth={args.zeroMinWidthContainer}
+      style={containerStyles}
+    >
+      <Grid {...itemArgs} style={itemStyles}>
+        1
+      </Grid>
+      <Grid {...itemArgs} style={itemStyles}>
+        2
+      </Grid>
+      <Grid {...itemArgs} style={itemStyles}>
+        3
+      </Grid>
+      <Grid {...itemArgs} style={itemStyles}>
+        4
+      </Grid>
+      <Grid {...itemArgs} style={{ ...itemStyles, height: 'auto' }}>
+        5
+        <br />
+        (taller)
+      </Grid>
+      <Grid {...itemArgs} style={itemStyles}>
+        6
+      </Grid>
+      <Grid {...itemArgs} style={itemStyles}>
+        7
+      </Grid>
+      <Grid {...itemArgs} style={itemStyles}>
+        8
+      </Grid>
+      <Grid {...itemArgs} style={itemStyles}>
+        9
+      </Grid>
+      <Grid
+        {...itemArgs}
+        style={{ ...itemStyles, width: 'auto', whiteSpace: 'nowrap' }}
+      >
+        10 (wider)
+      </Grid>
+      <Grid {...itemArgs} style={itemStyles}>
+        11
+      </Grid>
+      <Grid {...itemArgs} style={itemStyles}>
+        12
+      </Grid>
+      <Grid {...itemArgs} style={itemStyles}>
+        13
+      </Grid>
+      <Grid {...itemArgs} style={itemStyles}>
+        14
+      </Grid>
+    </Grid>
+  )
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  wrapContainer: 'wrap',
+  directionContainer: 'row',
+  justifyContentContainer: 'flex-start',
+  alignItemsContainer: 'flex-start',
+  zeroMinWidthContainer: false,
+  direction: 'row',
+  justifyContent: 'flex-start',
+  alignItems: 'flex-start',
+  zeroMinWidth: false,
+  xs: 6,
+  sm: 4,
+  md: 3,
+  lg: 2
+} as typeof Default.args

--- a/components/Grid/Grid.stories.tsx
+++ b/components/Grid/Grid.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react'
+import styled from '@emotion/styled'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 
 import { colors } from '@components/common/colors'
@@ -59,28 +61,18 @@ const argTypes = {
   alignItems: generateSelectArgType('alignItems', alignItemsOptions)
 }
 
-const itemStyles = {
-  background: colors.yellow,
-  color: colors.onyx,
+const mapArgsToContainerProps = (args: Record<string, unknown>) =>
+  ({
+    container: true,
+    wrap: args.wrapContainer,
+    direction: args.directionContainer,
+    justifyContent: args.justifyContentContainer,
+    alignItems: args.alignItemsContainer,
+    zeroMinWidth: args.zeroMinWidthContainer
+  } as GridProps)
 
-  padding: '5px',
-
-  'line-height': '100px',
-  'font-weight': 'bold',
-  'font-size': '2em',
-  'text-align': 'center'
-}
-
-export default {
-  title: 'Grid',
-  component: Grid,
-  argTypes,
-  subcomponents: { Grid }
-} as ComponentMeta<typeof Grid>
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const Template: ComponentStory<typeof Grid> = (args: Record<string, any>) => {
-  const itemArgs: GridProps = {
+const mapArgsToItemProps = (args: Record<string, unknown>) =>
+  ({
     item: true,
     direction: args.direction,
     justifyContent: args.justifyContent,
@@ -91,70 +83,75 @@ const Template: ComponentStory<typeof Grid> = (args: Record<string, any>) => {
     md: args.md,
     lg: args.lg,
     xl: args.xl
-  }
+  } as GridProps)
 
+type DemoDivProps = {
+  children: React.ReactNode
+  extraDemoDivStyles?: string
+}
+type DemoGridItemProps = GridProps & DemoDivProps
+
+const DemoGridItem = (props: DemoGridItemProps) => {
+  const DemoDiv = styled.div<{ extraStyles?: string }>`
+    background: ${colors.yellow};
+    color: ${colors.onyx};
+
+    padding: 5px;
+    line-height: 100px;
+    font-weight: bold;
+    font-size: 2em;
+    text-align: center;
+    ${({ extraStyles }) => extraStyles ?? ''}
+  `
   return (
-    <Grid
-      container
-      wrap={args.wrapContainer}
-      direction={args.directionContainer}
-      justifyContent={args.justifyContentContainer}
-      alignItems={args.alignItemsContainer}
-      zeroMinWidth={args.zeroMinWidthContainer}
-    >
-      <Grid {...itemArgs}>
-        <div style={itemStyles}>1</div>
-      </Grid>
-      <Grid {...itemArgs}>
-        <div style={itemStyles}>2</div>
-      </Grid>
-      <Grid {...itemArgs}>
-        <div style={itemStyles}>3</div>
-      </Grid>
-      <Grid {...itemArgs}>
-        <div style={itemStyles}>4</div>
-      </Grid>
-      <Grid {...itemArgs}>
-        <div style={itemStyles}>
-          5
-          <br />
-          (taller)
-        </div>
-      </Grid>
-      <Grid {...itemArgs}>
-        <div style={itemStyles}>6</div>
-      </Grid>
-      <Grid {...itemArgs}>
-        <div style={itemStyles}>7</div>
-      </Grid>
-      <Grid {...itemArgs}>
-        <div style={itemStyles}>8</div>
-      </Grid>
-      <Grid {...itemArgs}>
-        <div style={itemStyles}>9</div>
-      </Grid>
-      <Grid {...itemArgs}>
-        <div style={{ ...itemStyles, whiteSpace: 'nowrap' }}>
-          10 (this is a wide block)
-        </div>
-      </Grid>
-      <Grid {...itemArgs}>
-        <div style={itemStyles}>11</div>
-      </Grid>
-      <Grid {...itemArgs}>
-        <div style={itemStyles}>12</div>
-      </Grid>
-      <Grid {...itemArgs}>
-        <div style={itemStyles}>13</div>
-      </Grid>
-      <Grid {...itemArgs}>
-        <div style={itemStyles}>14</div>
-      </Grid>
+    <Grid {...props}>
+      <DemoDiv extraStyles={props.extraDemoDivStyles}>{props.children}</DemoDiv>
     </Grid>
   )
 }
 
-export const Default = Template.bind({})
+export default {
+  title: 'Grid',
+  component: Grid,
+  argTypes,
+  subcomponents: { Grid }
+} as ComponentMeta<typeof Grid>
+
+const DefaultTemplate: ComponentStory<typeof Grid> = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: Record<string, any>
+) => {
+  const containerProps = mapArgsToContainerProps(args)
+  const itemProps = mapArgsToItemProps(args)
+
+  const demoDivsProps: DemoDivProps[] = Array.from({ length: 14 }, (_, i) => ({
+    children: <React.Fragment>{String(i + 1)}</React.Fragment>
+  }))
+  demoDivsProps[4].children = (
+    <React.Fragment>
+      5<br />
+      (taller)
+    </React.Fragment>
+  )
+  demoDivsProps[9] = {
+    children: <span>10 (this is a wide block)</span>,
+    extraDemoDivStyles: 'white-space: nowrap;'
+  }
+
+  return (
+    <Grid {...containerProps}>
+      {demoDivsProps.map((demoDivProps) => (
+        <DemoGridItem
+          key={demoDivProps.children?.toString()}
+          {...itemProps}
+          {...demoDivProps}
+        ></DemoGridItem>
+      ))}
+    </Grid>
+  )
+}
+
+export const Default = DefaultTemplate.bind({})
 Default.args = {
   wrapContainer: 'wrap',
   directionContainer: 'row',

--- a/components/Grid/Grid.stories.tsx
+++ b/components/Grid/Grid.stories.tsx
@@ -58,7 +58,16 @@ const argTypes = {
     'justifyContent',
     justifyContentOptions
   ),
-  alignItems: generateSelectArgType('alignItems', alignItemsOptions)
+  alignItems: generateSelectArgType('alignItems', alignItemsOptions),
+  spacing: disabledArgType,
+  rowSpacing: {
+    name: 'Row Spacing',
+    control: { type: 'object' }
+  },
+  columnSpacing: {
+    name: 'Column Spacing',
+    control: { type: 'object' }
+  }
 }
 
 const mapArgsToContainerProps = (args: Record<string, unknown>) =>
@@ -68,6 +77,8 @@ const mapArgsToContainerProps = (args: Record<string, unknown>) =>
     direction: args.directionContainer,
     justifyContent: args.justifyContentContainer,
     alignItems: args.alignItemsContainer,
+    rowSpacing: args.rowSpacing,
+    columnSpacing: args.columnSpacing,
     zeroMinWidth: args.zeroMinWidthContainer
   } as GridProps)
 
@@ -161,9 +172,57 @@ Default.args = {
   direction: 'row',
   justifyContent: 'flex-start',
   alignItems: 'flex-start',
+  rowSpacing: { xs: 1, md: 3 },
+  columnSpacing: { xs: 1, sm: 2, lg: 4 },
   zeroMinWidth: false,
   xs: 6,
   sm: 4,
   md: 3,
   lg: 2
 } as typeof Default.args
+
+const NestedTemplate: ComponentStory<typeof Grid> = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: Record<string, any>
+) => {
+  const containerProps = mapArgsToContainerProps(args)
+  const subContainerProps: GridProps = {
+    ...mapArgsToContainerProps(args),
+    item: true,
+    xs: 12
+  }
+  const itemProps = mapArgsToItemProps(args)
+
+  return (
+    <Grid {...containerProps}>
+      <Grid {...subContainerProps}>
+        <DemoGridItem {...itemProps}>1</DemoGridItem>
+        <DemoGridItem {...itemProps}>2</DemoGridItem>
+        <DemoGridItem {...itemProps}>3</DemoGridItem>
+      </Grid>
+      <Grid {...subContainerProps}>
+        <DemoGridItem {...itemProps}>4</DemoGridItem>
+        <DemoGridItem {...itemProps}>5</DemoGridItem>
+      </Grid>
+      <Grid {...subContainerProps}>
+        <DemoGridItem {...itemProps}>6</DemoGridItem>
+      </Grid>
+    </Grid>
+  )
+}
+
+export const Nested = NestedTemplate.bind({})
+Nested.args = {
+  wrapContainer: 'wrap',
+  directionContainer: 'row',
+  justifyContentContainer: 'space-around',
+  alignItemsContainer: 'flex-start',
+  zeroMinWidthContainer: false,
+  direction: 'row',
+  justifyContent: 'flex-start',
+  alignItems: 'flex-start',
+  rowSpacing: 1,
+  columnSpacing: 1,
+  zeroMinWidth: false,
+  xs: 4
+} as typeof Nested.args

--- a/components/Grid/Grid.stories.tsx
+++ b/components/Grid/Grid.stories.tsx
@@ -5,7 +5,6 @@ import { colors } from '@components/common/colors'
 import { Grid } from './Grid'
 import { GridProps } from './Grid.model'
 
-// 1. Arg Types
 const disabledArgType = {
   table: {
     disable: true
@@ -60,17 +59,11 @@ const argTypes = {
   alignItems: generateSelectArgType('alignItems', alignItemsOptions)
 }
 
-// 2. Container & Item CSS Styles
-const containerStyles = {
-  border: `3px solid ${colors.onyx}`
-}
 const itemStyles = {
   background: colors.yellow,
   color: colors.onyx,
 
   padding: '5px',
-  height: '100px',
-  width: '100px',
 
   'line-height': '100px',
   'font-weight': 'bold',
@@ -78,7 +71,6 @@ const itemStyles = {
   'text-align': 'center'
 }
 
-// 3. Story
 export default {
   title: 'Grid',
   component: Grid,
@@ -109,54 +101,54 @@ const Template: ComponentStory<typeof Grid> = (args: Record<string, any>) => {
       justifyContent={args.justifyContentContainer}
       alignItems={args.alignItemsContainer}
       zeroMinWidth={args.zeroMinWidthContainer}
-      style={containerStyles}
     >
-      <Grid {...itemArgs} style={itemStyles}>
-        1
+      <Grid {...itemArgs}>
+        <div style={itemStyles}>1</div>
       </Grid>
-      <Grid {...itemArgs} style={itemStyles}>
-        2
+      <Grid {...itemArgs}>
+        <div style={itemStyles}>2</div>
       </Grid>
-      <Grid {...itemArgs} style={itemStyles}>
-        3
+      <Grid {...itemArgs}>
+        <div style={itemStyles}>3</div>
       </Grid>
-      <Grid {...itemArgs} style={itemStyles}>
-        4
+      <Grid {...itemArgs}>
+        <div style={itemStyles}>4</div>
       </Grid>
-      <Grid {...itemArgs} style={{ ...itemStyles, height: 'auto' }}>
-        5
-        <br />
-        (taller)
+      <Grid {...itemArgs}>
+        <div style={itemStyles}>
+          5
+          <br />
+          (taller)
+        </div>
       </Grid>
-      <Grid {...itemArgs} style={itemStyles}>
-        6
+      <Grid {...itemArgs}>
+        <div style={itemStyles}>6</div>
       </Grid>
-      <Grid {...itemArgs} style={itemStyles}>
-        7
+      <Grid {...itemArgs}>
+        <div style={itemStyles}>7</div>
       </Grid>
-      <Grid {...itemArgs} style={itemStyles}>
-        8
+      <Grid {...itemArgs}>
+        <div style={itemStyles}>8</div>
       </Grid>
-      <Grid {...itemArgs} style={itemStyles}>
-        9
+      <Grid {...itemArgs}>
+        <div style={itemStyles}>9</div>
       </Grid>
-      <Grid
-        {...itemArgs}
-        style={{ ...itemStyles, width: 'auto', whiteSpace: 'nowrap' }}
-      >
-        10 (wider)
+      <Grid {...itemArgs}>
+        <div style={{ ...itemStyles, whiteSpace: 'nowrap' }}>
+          10 (this is a wide block)
+        </div>
       </Grid>
-      <Grid {...itemArgs} style={itemStyles}>
-        11
+      <Grid {...itemArgs}>
+        <div style={itemStyles}>11</div>
       </Grid>
-      <Grid {...itemArgs} style={itemStyles}>
-        12
+      <Grid {...itemArgs}>
+        <div style={itemStyles}>12</div>
       </Grid>
-      <Grid {...itemArgs} style={itemStyles}>
-        13
+      <Grid {...itemArgs}>
+        <div style={itemStyles}>13</div>
       </Grid>
-      <Grid {...itemArgs} style={itemStyles}>
-        14
+      <Grid {...itemArgs}>
+        <div style={itemStyles}>14</div>
       </Grid>
     </Grid>
   )

--- a/components/Grid/Grid.stories.tsx
+++ b/components/Grid/Grid.stories.tsx
@@ -151,12 +151,8 @@ const DefaultTemplate: ComponentStory<typeof Grid> = (
 
   return (
     <Grid {...containerProps}>
-      {demoDivsProps.map((demoDivProps) => (
-        <DemoGridItem
-          key={demoDivProps.children?.toString()}
-          {...itemProps}
-          {...demoDivProps}
-        ></DemoGridItem>
+      {demoDivsProps.map((demoDivProps, i) => (
+        <DemoGridItem key={i} {...itemProps} {...demoDivProps}></DemoGridItem>
       ))}
     </Grid>
   )

--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -6,31 +6,36 @@ import {
   NUM_TOTAL_GRID_COLUMNS
 } from '@components/common/spaces'
 
-import { GridProps } from './Grid.model'
+import { GridFlexBasis, GridProps } from './Grid.model'
 
-const getMediaQueryLabel = (breakpoint: BREAKPOINT) =>
-  `@media (min-width: ${BREAKPOINTS[breakpoint]}px)`
+const getWrappedMediaQueryRule = (breakpoint: BREAKPOINT, rule: string) =>
+  `
+  @media (min-width: ${BREAKPOINTS[breakpoint]}px) {
+    ${rule}
+  }`
 
 const getFlexBasis = (numColumns: number) =>
   Math.min((numColumns / NUM_TOTAL_GRID_COLUMNS) * 100, 100)
 
-const getMediaQueriesWithFlexBasis = (
-  numColumnsByBreakpoint: Partial<Record<BREAKPOINT, number>>
+const getAllFlexBasisStyles = (
+  numColumnsByBreakpoint: Partial<Record<BREAKPOINT, GridFlexBasis>>
 ) => {
-  let queries = ''
+  let styles = ''
 
   let breakpoint: BREAKPOINT
   for (breakpoint in BREAKPOINTS) {
     const numColumns = numColumnsByBreakpoint[breakpoint]
     if (numColumns) {
-      queries += `
-      ${getMediaQueryLabel(breakpoint)} {
-        flex: 0 0 ${getFlexBasis(numColumns)}%
-      }`
+      const flexBasis =
+        numColumns === 'auto' ? numColumns : `${getFlexBasis(numColumns)}%`
+      styles += getWrappedMediaQueryRule(
+        breakpoint,
+        `flex-basis: ${flexBasis};`
+      )
     }
   }
 
-  return queries
+  return styles
 }
 
 export const Grid = styled.div<GridProps>((inProps: GridProps) => {
@@ -58,5 +63,8 @@ export const Grid = styled.div<GridProps>((inProps: GridProps) => {
       width: 100%;`
   }
 
-  return `${baseStyles}${getMediaQueriesWithFlexBasis(props)}`
+  return `${baseStyles}
+    flex-grow: 0;
+    flex-shrink: 0;
+    ${getAllFlexBasisStyles(props)}`
 })

--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -12,7 +12,7 @@ const getMediaQueryLabel = (breakpoint: BREAKPOINT) =>
   `@media (min-width: ${BREAKPOINTS[breakpoint]}px)`
 
 const getFlexBasis = (numColumns: number) =>
-  (numColumns / NUM_TOTAL_GRID_COLUMNS) * 100
+  Math.min((numColumns / NUM_TOTAL_GRID_COLUMNS) * 100, 100)
 
 const getMediaQueriesWithFlexBasis = (
   numColumnsByBreakpoint: Partial<Record<BREAKPOINT, number>>

--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -3,10 +3,11 @@ import styled from '@emotion/styled'
 import {
   BREAKPOINT,
   BREAKPOINTS,
+  GRID_SPACING_PX_UNIT,
   NUM_TOTAL_GRID_COLUMNS
 } from '@components/common/spaces'
 
-import { GridFlexBasis, GridProps } from './Grid.model'
+import { GridFlexBasis, GridProps, GridSpacing } from './Grid.model'
 
 const getWrappedMediaQueryRule = (breakpoint: BREAKPOINT, rule: string) =>
   `
@@ -14,10 +15,130 @@ const getWrappedMediaQueryRule = (breakpoint: BREAKPOINT, rule: string) =>
     ${rule}
   }`
 
+const getSpacingInPx = (spacing: number | undefined) =>
+  spacing !== undefined ? spacing * GRID_SPACING_PX_UNIT : undefined
+
+const getContainerWidthAndMarginOffsets = (
+  rowSpacing: number | undefined,
+  columnSpacing: number | undefined,
+  useExplicitWidth = false
+) => {
+  const rowPx = getSpacingInPx(rowSpacing)
+  const columnPx = getSpacingInPx(columnSpacing)
+
+  let horizontalRules = ''
+  if (columnPx) {
+    horizontalRules = `width: calc(100% + ${columnPx}px);
+      margin-left: ${columnPx / -2}px;
+      margin-right: ${columnPx / -2}px;`
+  } else if (useExplicitWidth) {
+    horizontalRules = 'width: 100%;'
+  }
+
+  const verticalRules = rowPx
+    ? `
+      margin-top: ${rowPx / -2}px;
+      margin-bottom: ${rowPx / -2}px;`
+    : ''
+
+  return `${horizontalRules}${verticalRules}`
+}
+
+const getAllContainerWidthAndMarginOffsets = (
+  rowSpacing: GridSpacing | undefined,
+  columnSpacing: GridSpacing | undefined
+) => {
+  let styles = getContainerWidthAndMarginOffsets(
+    typeof rowSpacing === 'number' ? rowSpacing : undefined,
+    typeof columnSpacing === 'number' ? columnSpacing : undefined,
+    true
+  )
+
+  let breakpoint: BREAKPOINT
+  for (breakpoint in BREAKPOINTS) {
+    const rowSpacingForBreakpoint =
+      typeof rowSpacing === 'object' ? rowSpacing[breakpoint] : undefined
+    const columnSpacingForBreakpoint =
+      typeof columnSpacing === 'object' ? columnSpacing[breakpoint] : undefined
+
+    if (
+      rowSpacingForBreakpoint !== undefined ||
+      columnSpacingForBreakpoint !== undefined
+    ) {
+      styles += getWrappedMediaQueryRule(
+        breakpoint,
+        getContainerWidthAndMarginOffsets(
+          rowSpacingForBreakpoint,
+          columnSpacingForBreakpoint
+        )
+      )
+    }
+  }
+
+  return styles
+}
+
+const getItemPadding = (
+  rowSpacing: number | undefined,
+  columnSpacing: number | undefined
+) => {
+  const rowPx = getSpacingInPx(rowSpacing)
+  const columnPx = getSpacingInPx(columnSpacing)
+
+  const horizontalPadding = columnPx
+    ? `padding-left: ${columnPx / 2}px;
+      padding-right: ${columnPx / 2}px;`
+    : ''
+
+  const verticalPadding = rowPx
+    ? `
+      padding-top: ${rowPx / 2}px;
+      padding-bottom: ${rowPx / 2}px;`
+    : ''
+
+  return `${horizontalPadding}${verticalPadding}`
+}
+
+const getAllItemPadding = (
+  rowSpacing: GridSpacing | undefined,
+  columnSpacing: GridSpacing | undefined
+) => {
+  let styles = ''
+  if (!rowSpacing && !columnSpacing) {
+    return ''
+  } else if (
+    typeof rowSpacing === 'number' &&
+    typeof columnSpacing === 'number'
+  ) {
+    styles = getItemPadding(rowSpacing, columnSpacing)
+  }
+
+  let breakpoint: BREAKPOINT
+  for (breakpoint in BREAKPOINTS) {
+    const rowSpacingForBreakpoint =
+      typeof rowSpacing === 'object' ? rowSpacing[breakpoint] : undefined
+    const columnSpacingForBreakpoint =
+      typeof columnSpacing === 'object' ? columnSpacing[breakpoint] : undefined
+    if (
+      rowSpacingForBreakpoint !== undefined ||
+      columnSpacingForBreakpoint !== undefined
+    ) {
+      styles += getWrappedMediaQueryRule(
+        breakpoint,
+        getItemPadding(rowSpacingForBreakpoint, columnSpacingForBreakpoint)
+      )
+    }
+  }
+
+  return `& > * {
+    ${styles}
+  }`
+}
+
 const getFlexBasis = (numColumns: number) =>
   Math.min((numColumns / NUM_TOTAL_GRID_COLUMNS) * 100, 100)
 
-const getAllFlexBasisStyles = (
+const getAllFlexBasisAndMaxWidthStyles = (
   numColumnsByBreakpoint: Partial<Record<BREAKPOINT, GridFlexBasis>>
 ) => {
   let styles = ''
@@ -30,7 +151,8 @@ const getAllFlexBasisStyles = (
         numColumns === 'auto' ? numColumns : `${getFlexBasis(numColumns)}%`
       styles += getWrappedMediaQueryRule(
         breakpoint,
-        `flex-basis: ${flexBasis};`
+        `flex-basis: ${flexBasis};
+        max-width: ${flexBasis};`
       )
     }
   }
@@ -46,25 +168,32 @@ export const Grid = styled.div<GridProps>((inProps: GridProps) => {
     direction: 'row',
     justifyContent: 'flex-start',
     alignItems: 'flex-start',
+    spacing: 0,
     zeroMinWidth: false,
     ...inProps
   }
 
-  const baseStyles = `box-sizing: 'border-box';
+  const rowSpacing = props.rowSpacing ?? props.spacing
+  const columnSpacing = props.columnSpacing ?? props.spacing
+
+  let styles = `box-sizing: border-box;
     flex-direction: ${props.direction};
     justify-content: ${props.justifyContent};
     align-items: ${props.alignItems};
     ${props.zeroMinWidth ? 'min-width: 0;' : ''}`
 
   if (props.container) {
-    return `${baseStyles}
+    styles += `
       display: flex;
       flex-wrap: ${props.wrap};
-      width: 100%;`
+      
+      ${getAllContainerWidthAndMarginOffsets(rowSpacing, columnSpacing)}
+      
+      ${getAllItemPadding(rowSpacing, columnSpacing)}`
+  }
+  if (props.item) {
+    styles += getAllFlexBasisAndMaxWidthStyles(props)
   }
 
-  return `${baseStyles}
-    flex-grow: 0;
-    flex-shrink: 0;
-    ${getAllFlexBasisStyles(props)}`
+  return styles
 })

--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -1,0 +1,62 @@
+import styled from '@emotion/styled'
+
+import {
+  BREAKPOINT,
+  BREAKPOINTS,
+  NUM_TOTAL_GRID_COLUMNS
+} from '@components/common/spaces'
+
+import { GridProps } from './Grid.model'
+
+const getMediaQueryLabel = (breakpoint: BREAKPOINT) =>
+  `@media (min-width: ${BREAKPOINTS[breakpoint]}px)`
+
+const getFlexBasis = (numColumns: number) =>
+  (numColumns / NUM_TOTAL_GRID_COLUMNS) * 100
+
+const getMediaQueriesWithFlexBasis = (
+  numColumnsByBreakpoint: Partial<Record<BREAKPOINT, number>>
+) => {
+  let queries = ''
+
+  let breakpoint: BREAKPOINT
+  for (breakpoint in BREAKPOINTS) {
+    const numColumns = numColumnsByBreakpoint[breakpoint]
+    if (numColumns) {
+      queries += `
+      ${getMediaQueryLabel(breakpoint)} {
+        flex: 0 0 ${getFlexBasis(numColumns)}%
+      }`
+    }
+  }
+
+  return queries
+}
+
+export const Grid = styled.div<GridProps>((inProps: GridProps) => {
+  const props: GridProps = {
+    container: false,
+    item: false,
+    wrap: 'wrap',
+    direction: 'row',
+    justifyContent: 'flex-start',
+    alignItems: 'flex-start',
+    zeroMinWidth: false,
+    ...inProps
+  }
+
+  const baseStyles = `box-sizing: 'border-box';
+    flex-direction: ${props.direction};
+    justify-content: ${props.justifyContent};
+    align-items: ${props.alignItems};
+    ${props.zeroMinWidth ? 'min-width: 0;' : ''}`
+
+  if (props.container) {
+    return `${baseStyles}
+      display: flex;
+      flex-wrap: ${props.wrap};
+      width: 100%;`
+  }
+
+  return `${baseStyles}${getMediaQueriesWithFlexBasis(props)}`
+})

--- a/components/Grid/index.ts
+++ b/components/Grid/index.ts
@@ -1,0 +1,2 @@
+export * from './Grid.model'
+export * from './Grid'

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,7 +1,6 @@
-import { Grid } from '@mui/material'
-
 import { GhostSettings } from '@lib/ghost'
 
+import { Grid } from '@components/Grid'
 import { SiteNav } from '@components/SiteNav'
 import { Heading } from '@components/typography/Headings'
 import { Subheading } from '@components/typography/Subheadings'

--- a/components/PostItems.tsx
+++ b/components/PostItems.tsx
@@ -1,11 +1,12 @@
-import Grid from '@mui/material/Grid'
 import { useRouter } from 'next/router'
 
 import { GhostPostOrPage, GhostPostsOrPages, GhostSettings } from '@lib/ghost'
 
 import { FilterTags } from '@components/FilterTags'
-import { PostCard } from '@components/PostCard'
 import { FirstPost } from '@components/FirstPost'
+import { Grid } from '@components/Grid'
+import { PostCard } from '@components/PostCard'
+
 interface PostItemsProps {
   settings: GhostSettings
   posts: GhostPostsOrPages

--- a/components/PreviewPosts/index.tsx
+++ b/components/PreviewPosts/index.tsx
@@ -1,7 +1,6 @@
-import Grid from '@mui/material/Grid'
-
 import { GhostPostOrPage, GhostSettings } from '@lib/ghost'
 
+import { Grid } from '@components/Grid'
 import { PostCard } from '@components/PostCard'
 import { Heading } from '@components/typography/Headings'
 

--- a/components/Subscribe/index.tsx
+++ b/components/Subscribe/index.tsx
@@ -1,11 +1,11 @@
-import Grid from '@mui/material/Grid'
 import styled from '@emotion/styled'
 
 import { GhostSettings } from '@lib/ghost'
 import { get, getLang } from '@utils/use-lang'
 
-import { Copy } from '@components/typography/Copy'
 import { spaces } from '@components/common/spaces'
+import { Grid } from '@components/Grid'
+import { Copy } from '@components/typography/Copy'
 import { Heading } from '@components/typography/Headings'
 
 import { DescriptionLink } from './components'

--- a/components/common/spaces.ts
+++ b/components/common/spaces.ts
@@ -26,6 +26,11 @@ export const spaces = {
 export const NUM_TOTAL_GRID_COLUMNS = 12
 
 /**
+ * Number of pixels (px) per grid spacing unit
+ */
+export const GRID_SPACING_PX_UNIT = 8
+
+/**
  * Possible breakpoint values
  */
 export type BREAKPOINT = 'xs' | 'sm' | 'md' | 'lg' | 'xl'

--- a/components/common/spaces.ts
+++ b/components/common/spaces.ts
@@ -19,3 +19,25 @@ export const spaces = {
   xxxl: 80,
   xxxxl: 120
 }
+
+/**
+ * Total number of available columns in a grid
+ */
+export const NUM_TOTAL_GRID_COLUMNS = 12
+
+/**
+ * Possible breakpoint values
+ */
+export type BREAKPOINT = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+
+/**
+ * Breakpoint definitions based on the default breakpoints from Material UI: https://mui.com/material-ui/customization/breakpoints/#default-breakpoints
+ *  * Note that the "xl" breakpoint is equal to MAX_WIDTH instead of the default value of 1536px
+ */
+export const BREAKPOINTS: Record<BREAKPOINT, number> = {
+  xs: 0,
+  sm: 600,
+  md: 900,
+  lg: 1200,
+  xl: MAX_WIDTH
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
-    "@mui/material": "^5.5.3",
     "@tryghost/admin-api": "^1.6.0",
     "@tryghost/content-api": "^1.6.0",
     "cheerio": "^1.0.0-rc.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1074,7 +1074,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.2", "@babel/runtime@^7.17.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
   integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
@@ -1653,86 +1653,6 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@mui/base@5.0.0-alpha.81":
-  version "5.0.0-alpha.81"
-  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.81.tgz#3ae1fc2e49bfccb4195eab5d9eacf0bca8398f80"
-  integrity sha512-KJP+RdKBLSbhiAliy1b5xFuoAezawupfIHc/MRtEZdqAmUW0+UFNDXIUDlBKR9zLCjgjQ7eVJsSe0TwAgd8OMQ==
-  dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@emotion/is-prop-valid" "^1.1.2"
-    "@mui/types" "^7.1.3"
-    "@mui/utils" "^5.8.0"
-    "@popperjs/core" "^2.11.5"
-    clsx "^1.1.1"
-    prop-types "^15.8.1"
-    react-is "^17.0.2"
-
-"@mui/material@^5.5.3":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.8.0.tgz#7451cecde57a24a9c407ec5122369240f5e7fae3"
-  integrity sha512-yvt3sUmUZ1i8SPadRYBCThcB57lBZsvyhC7ufVpRxA3AD39O+WXtXAapEfpDdDkJnnKb5MCimDMwBYgWLmY89Q==
-  dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@mui/base" "5.0.0-alpha.81"
-    "@mui/system" "^5.8.0"
-    "@mui/types" "^7.1.3"
-    "@mui/utils" "^5.8.0"
-    "@types/react-transition-group" "^4.4.4"
-    clsx "^1.1.1"
-    csstype "^3.0.11"
-    hoist-non-react-statics "^3.3.2"
-    prop-types "^15.8.1"
-    react-is "^17.0.2"
-    react-transition-group "^4.4.2"
-
-"@mui/private-theming@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.8.0.tgz#7d927e7e12616dc10b0dcbe665df2c00ed859796"
-  integrity sha512-MjRAneTmCKLR9u2S4jtjLUe6gpHxlbb4g2bqpDJ2PdwlvwsWIUzbc/gVB4dvccljXeWxr5G2M/Co2blXisvFIw==
-  dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@mui/utils" "^5.8.0"
-    prop-types "^15.8.1"
-
-"@mui/styled-engine@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.8.0.tgz#89ed42efe7c8749e5a60af035bc5d3a6bea362bf"
-  integrity sha512-Q3spibB8/EgeMYHc+/o3RRTnAYkSl7ROCLhXJ830W8HZ2/iDiyYp16UcxKPurkXvLhUaILyofPVrP3Su2uKsAw==
-  dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@emotion/cache" "^11.7.1"
-    prop-types "^15.8.1"
-
-"@mui/system@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.8.0.tgz#5e8fe9016727863eb1b467ed44398a9bab25a7a2"
-  integrity sha512-1tEj2S59RjlZ/6JMJMUktQDbV2ev7hyGXqO7dRRUQ7nOJi9qHmCFP0uXj3YS6LbM6hVasgYXJg8GBjbEtfTJvg==
-  dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@mui/private-theming" "^5.8.0"
-    "@mui/styled-engine" "^5.8.0"
-    "@mui/types" "^7.1.3"
-    "@mui/utils" "^5.8.0"
-    clsx "^1.1.1"
-    csstype "^3.0.11"
-    prop-types "^15.8.1"
-
-"@mui/types@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.1.3.tgz#d7636f3046110bcccc63e6acfd100e2ad9ca712a"
-  integrity sha512-DDF0UhMBo4Uezlk+6QxrlDbchF79XG6Zs0zIewlR4c0Dt6GKVFfUtzPtHCH1tTbcSlq/L2bGEdiaoHBJ9Y1gSA==
-
-"@mui/utils@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.8.0.tgz#4b1d19cbcf70773283375e763b7b3552b84cb58f"
-  integrity sha512-7LgUtCvz78676iC0wpTH7HizMdCrTphhBmRWimIMFrp5Ph6JbDFVuKS1CwYnWWxRyYKL0QzXrDL0lptAU90EXg==
-  dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@types/prop-types" "^15.7.5"
-    "@types/react-is" "^16.7.1 || ^17.0.0"
-    prop-types "^15.8.1"
-    react-is "^17.0.2"
-
 "@next/bundle-analyzer@^12.0.10":
   version "12.1.6"
   resolved "https://registry.yarnpkg.com/@next/bundle-analyzer/-/bundle-analyzer-12.1.6.tgz#5f4efcdb8c91d70c8be6013b0aacdb4d89ba1312"
@@ -1873,11 +1793,6 @@
   version "1.0.0-next.21"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
-
-"@popperjs/core@^2.11.5":
-  version "2.11.5"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
-  integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
 
 "@rushstack/eslint-patch@^1.1.3":
   version "1.1.3"
@@ -3159,7 +3074,7 @@
   resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.26.0.tgz#a1c3809b0ad61c62cac6d4e0c56d610c910b7654"
   integrity sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==
 
-"@types/prop-types@*", "@types/prop-types@^15.7.5":
+"@types/prop-types@*":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
@@ -3176,24 +3091,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-is@^16.7.1 || ^17.0.0":
-  version "17.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
-  integrity sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz#0d546261b4021e1f9d85b50401c0a42acb106087"
   integrity sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-transition-group@^4.4.4":
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
-  integrity sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==
   dependencies:
     "@types/react" "*"
 
@@ -4950,7 +4851,7 @@ clsx@1.1.0:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
   integrity sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==
 
-clsx@^1.0.4, clsx@^1.1.1:
+clsx@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -5441,7 +5342,7 @@ csstype@^2.5.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.20.tgz#9229c65ea0b260cf4d3d997cb06288e36a8d6dda"
   integrity sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==
 
-csstype@^3.0.11, csstype@^3.0.2:
+csstype@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
   integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
@@ -5683,14 +5584,6 @@ dom-converter@^0.2.0:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
-
-dom-helpers@^5.0.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
-  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    csstype "^3.0.2"
 
 dom-serializer@^1.0.1, dom-serializer@^1.3.2:
   version "1.4.1"
@@ -7320,7 +7213,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -10331,7 +10224,7 @@ prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -10610,16 +10503,6 @@ react-syntax-highlighter@^15.4.5:
     lowlight "^1.17.0"
     prismjs "^1.27.0"
     refractor "^3.6.0"
-
-react-transition-group@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
-  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    dom-helpers "^5.0.1"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
 
 react@17.0.2:
   version "17.0.2"


### PR DESCRIPTION
Included in this PR:
- New Grid component (see details below)
- Adds two stories for the new Grid component ("Default" and "Nested")
- Updates all <Grid> references to use new Grid component instead of from Material UI
- Removes Material UI dependency

New Grid component details:
- Based on Material UI & Bootstrap implementations and uses flexbox
- Single tag for both grid containers and grid items; consumer sets consumer and item booleans
- Supports nesting
- Supports flex-direction, justify-content, and align-items options
- Container Grid supports wrap options
- Container Grid supports rowSpacing, columnSpacing, or spacing (for both); input can be a number or an object for spacing based on breakpoints
- Item Grid supports relative (to 12-column grid) sizing based on breakpoints (e.g., xs={12} md={6})

This PR closes #53

<img width="1010" alt="grid-storybook-default-story" src="https://user-images.githubusercontent.com/6434784/179048061-824c0819-6c3b-41ad-9f7d-32359d05abe0.png">
